### PR TITLE
#92 test : order usecase 테스트 코드 작성

### DIFF
--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/inventory/RegisterInventoryUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/inventory/RegisterInventoryUseCaseTest.kt
@@ -10,7 +10,6 @@ import io.mockk.junit5.MockKExtension
 import kotlinx.coroutines.test.runTest
 import okhttp3.MultipartBody
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/CancelOrderUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/CancelOrderUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("CancelOrderUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class CancelOrderUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: CancelOrderUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = CancelOrderUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("주문 취소 성공 시, Result.success(Unit)를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val orderId = "ORDER123"
+        coEvery { mockRepo.cancelOrder(orderId) } returns Result.success(Unit)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(Unit, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.cancelOrder(orderId) }
+    }
+
+    @Test
+    @DisplayName("주문 취소 실패 시, Result.failure 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val orderId = "ORDER_INVALID"
+        val error = RuntimeException("Cancel failed")
+        coEvery { mockRepo.cancelOrder(orderId) } returns Result.failure(error)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.cancelOrder(orderId) }
+    }
+}

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/CompleteOrderPickingUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/CompleteOrderPickingUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("CompleteOrderPickingsUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class CompleteOrderPickingUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: CompleteOrderPickingsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = CompleteOrderPickingsUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("모든 피킹 완료 성공 시, Result.success(Unit)를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val orderId = "ORDER123"
+        coEvery { mockRepo.completeOrderPickings(orderId) } returns Result.success(Unit)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(Unit, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.completeOrderPickings(orderId) }
+    }
+
+    @Test
+    @DisplayName("모든 피킹 완료 실패 시, Result.failure 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val orderId = "ORDER_INVALID"
+        val error = IllegalStateException("Complete pickings failed")
+        coEvery { mockRepo.completeOrderPickings(orderId) } returns Result.failure(error)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.completeOrderPickings(orderId) }
+    }
+}

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/CompleteSinglePickingUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/CompleteSinglePickingUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.data.model.request.order.OrderInventoryPickingRequestDto
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("CompleteSinglePickingUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class CompleteSinglePickingUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: CompleteSinglePickingUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = CompleteSinglePickingUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("단일 피킹 완료 성공 시, Result.success(Unit)를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val orderId = "ORDER123"
+        val request = OrderInventoryPickingRequestDto(barcodeId = "ABC123")
+        coEvery { mockRepo.completeSinglePicking(orderId, request) } returns Result.success(Unit)
+
+        // when
+        val result = useCase(orderId, request)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(Unit, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.completeSinglePicking(orderId, request) }
+    }
+
+    @Test
+    @DisplayName("단일 피킹 완료 실패 시, Result.failure 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val orderId = "ORDER_INVALID"
+        val request = OrderInventoryPickingRequestDto(barcodeId = "XYZ999")
+        val error = RuntimeException("Complete single picking failed")
+        coEvery { mockRepo.completeSinglePicking(orderId, request) } returns Result.failure(error)
+
+        // when
+        val result = useCase(orderId, request)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.completeSinglePicking(orderId, request) }
+    }
+}

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/LoadCompletedPickingListUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/LoadCompletedPickingListUseCaseTest.kt
@@ -1,0 +1,78 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.domain.model.OrderListPage
+import com.inha.sellstarter_android.domain.model.OrderSummary
+import com.inha.sellstarter_android.domain.model.type.ChannelPlatform
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("LoadCompletedPickingListUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class LoadCompletedPickingListUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: LoadCompletedPickingListUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = LoadCompletedPickingListUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("피킹완료 리스트 조회 성공 시, OrderListPage를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val page = 0
+        val size = 10
+        val summaries = listOf(
+            OrderSummary(orderId = "O1", orderDate = "2025-06-30", channel = ChannelPlatform.SHOPIFY, inventoryItem = "ItemA"),
+            OrderSummary(orderId = "O2", orderDate = "2025-06-29", channel = ChannelPlatform.NAVER, inventoryItem = null)
+        )
+        val expected = OrderListPage(
+            orders = summaries,
+            page = page,
+            size = size,
+            totalElements = 2,
+            totalPages = 1
+        )
+        coEvery { mockRepo.loadCompletedPickingList(page = page, size = size) } returns Result.success(expected)
+
+        // when
+        val result = useCase(page, size)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.loadCompletedPickingList(page = page, size = size) }
+    }
+
+    @Test
+    @DisplayName("피킹완료 리스트 조회 실패 시, 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val page = 1
+        val size = 5
+        val error = RuntimeException("Load failed")
+        coEvery { mockRepo.loadCompletedPickingList(page = page, size = size) } returns Result.failure(error)
+
+        // when
+        val result = useCase(page, size)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.loadCompletedPickingList(page = page, size = size) }
+    }
+}

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/LoadOrderConfirmListUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/LoadOrderConfirmListUseCaseTest.kt
@@ -1,0 +1,78 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.domain.model.OrderListPage
+import com.inha.sellstarter_android.domain.model.OrderSummary
+import com.inha.sellstarter_android.domain.model.type.ChannelPlatform
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("LoadOrderConfirmListUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class LoadOrderConfirmListUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: LoadOrderConfirmListUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = LoadOrderConfirmListUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("주문확인 리스트 조회 성공 시, OrderListPage를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val page = 0
+        val size = 10
+        val summaries = listOf(
+            OrderSummary(orderId = "ORDER123", orderDate = "2025-06-30", channel = ChannelPlatform.SHOPIFY, inventoryItem = "ItemX"),
+            OrderSummary(orderId = "ORDER456", orderDate = "2025-06-29", channel = ChannelPlatform.NAVER, inventoryItem = "ItemY")
+        )
+        val expected = OrderListPage(
+            orders = summaries,
+            page = page,
+            size = size,
+            totalElements = summaries.size,
+            totalPages = 1
+        )
+        coEvery { mockRepo.loadOrderConfirmList(page = page, size = size) } returns Result.success(expected)
+
+        // when
+        val result = useCase(page, size)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.loadOrderConfirmList(page = page, size = size) }
+    }
+
+    @Test
+    @DisplayName("주문확인 리스트 조회 실패 시, 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val page = 1
+        val size = 5
+        val error = RuntimeException("Load confirm-list failed")
+        coEvery { mockRepo.loadOrderConfirmList(page = page, size = size) } returns Result.failure(error)
+
+        // when
+        val result = useCase(page, size)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.loadOrderConfirmList(page = page, size = size) }
+    }
+}

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/LoadOrderDetailUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/LoadOrderDetailUseCaseTest.kt
@@ -1,0 +1,102 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.domain.model.BuyerInfo
+import com.inha.sellstarter_android.domain.model.OrderDetailInfo
+import com.inha.sellstarter_android.domain.model.OrderInfo
+import com.inha.sellstarter_android.domain.model.OrderPickingInventory
+import com.inha.sellstarter_android.domain.model.PickingInfo
+import com.inha.sellstarter_android.domain.model.type.OrderStatusType
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("LoadOrderConfirmationDetailUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class LoadOrderDetailUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: LoadOrderConfirmationDetailUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = LoadOrderConfirmationDetailUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 성공 시, OrderDetailInfo를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val orderId = "ORDER123"
+        val orderInfo = OrderInfo(
+            orderId = orderId,
+            channelName = "WEB",
+            orderStatus = OrderStatusType.PIKING_COMPLETED
+        )
+        val items = listOf(
+            OrderPickingInventory(
+                inventoryName = "Item A",
+                barcodeId = "ABC123",
+                inventoryCount = 2,
+                isPicked = true
+            ),
+            OrderPickingInventory(
+                inventoryName = "Item B",
+                barcodeId = "DEF456",
+                inventoryCount = 1,
+                isPicked = true
+            )
+        )
+        val pickingInfo = PickingInfo(
+            items = items,
+            allPicked = true
+        )
+        val buyerInfo = BuyerInfo(
+            purchaserName = "Jane Doe",
+            purchaserAddress = "123 Main St",
+            purchaserRequest = "Leave at door"
+        )
+        val expected = OrderDetailInfo(
+            orderInfo = orderInfo,
+            pickingInfo = pickingInfo,
+            buyerInfo = buyerInfo
+        )
+
+        coEvery { mockRepo.loadOrderConfirmationDetail(orderId) } returns Result.success(expected)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.loadOrderConfirmationDetail(orderId) }
+    }
+
+    @Test
+    @DisplayName("문 상세 조회 실패 시, 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val orderId = "ORDER_INVALID"
+        val error = RuntimeException("Detail load failed")
+        coEvery { mockRepo.loadOrderConfirmationDetail(orderId) } returns Result.failure(error)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.loadOrderConfirmationDetail(orderId) }
+    }
+}

--- a/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/ShipOrderUseCaseTest.kt
+++ b/app/src/test/java/com/inha/sellstarter_android/domain/usecase/order/ShipOrderUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.inha.sellstarter_android.domain.usecase.order
+
+import com.inha.sellstarter_android.domain.repository.OrderRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.extension.ExtendWith
+
+@DisplayName("ShipOrderUseCase 테스트")
+@ExtendWith(MockKExtension::class)
+class ShipOrderUseCaseTest {
+
+    @MockK
+    lateinit var mockRepo: OrderRepository
+    private lateinit var useCase: ShipOrderUseCase
+
+    @BeforeEach
+    fun setUp() {
+        useCase = ShipOrderUseCase(mockRepo)
+    }
+
+    @Test
+    @DisplayName("주문 출고 완료 성공 시, Result.success(Unit)를 반환한다")
+    fun successCase() = runTest {
+        // given
+        val orderId = "ORDER123"
+        coEvery { mockRepo.shipOrder(orderId) } returns Result.success(Unit)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isSuccess)
+        assertEquals(Unit, result.getOrNull())
+        coVerify(exactly = 1) { mockRepo.shipOrder(orderId) }
+    }
+
+    @Test
+    @DisplayName("주문 배송 처리 실패 시, Result.failure 예외를 반환한다")
+    fun failureCase() = runTest {
+        // given
+        val orderId = "ORDER_INVALID"
+        val error = IllegalStateException("Ship failed")
+        coEvery { mockRepo.shipOrder(orderId) } returns Result.failure(error)
+
+        // when
+        val result = useCase(orderId)
+
+        // then
+        assertTrue(result.isFailure)
+        assertSame(error, result.exceptionOrNull())
+        coVerify(exactly = 1) { mockRepo.shipOrder(orderId) }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #92 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] 주문확인, 피킹완료 리스트 테스트코드 작성
- [x] 주문 상세 테스트 코드
- [x] 출고완료, 취소, 피킹완료 테스트코드 
### 스크린샷 (선택)

## 💬참고 사항 및 공부


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new unit tests for order-related features, including order cancellation, picking completion, order detail loading, order confirmation list loading, completed picking list loading, and shipping.
  * Improved test coverage for inventory registration by updating test imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->